### PR TITLE
fix module name

### DIFF
--- a/benches/bench_poseidon_hash.rs
+++ b/benches/bench_poseidon_hash.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use ark_bn254::Fr;
-use poseidon_rs::Poseidon;
+use poseidon_ark::Poseidon;
 
 use ark_std::str::FromStr;
 


### PR DESCRIPTION
Change the module name from `poseidon_rs` to `poseidon_ark` to be able to run `cargo bench`.